### PR TITLE
Allowed multiple mapping of roles with diff district

### DIFF
--- a/src/app/app-provider-admin/provider-admin/activities/work-location-mapping/work-location-mapping.component.html
+++ b/src/app/app-provider-admin/provider-admin/activities/work-location-mapping/work-location-mapping.component.html
@@ -292,7 +292,7 @@
                 [(ngModel)]="Serviceblock"
                 (selectionChange)="getVillageMaster(Serviceblock)"
                 name="Serviceblock"
-                required
+                [required]="isBlockRequired"
               >
                 <mat-option *ngFor="let item of blocks" [value]="item">
                   {{ item.blockName }}
@@ -309,7 +309,7 @@
                 [multiple]="true"
                 [(ngModel)]="Servicevillage"
                 name="Servicevillage"
-                required
+                [required]="isVillageRequired"
               >
                 <mat-option *ngFor="let item of village" [value]="item">
                   {{ item.villageName }}

--- a/src/app/app-provider-admin/provider-admin/activities/work-location-mapping/work-location-mapping.component.ts
+++ b/src/app/app-provider-admin/provider-admin/activities/work-location-mapping/work-location-mapping.component.ts
@@ -154,6 +154,8 @@ export class WorkLocationMappingComponent implements OnInit {
   villageIdValue: any;
   item: any;
   workplaceform: any;
+  isVillageRequired = true;
+  isBlockRequired = true;
 
   constructor(
     private alertService: ConfirmationDialogsService,
@@ -406,7 +408,19 @@ export class WorkLocationMappingComponent implements OnInit {
         mappedWorkLocations.providerServiceMapID === providerServiceMapID &&
         mappedWorkLocations.userID === userID
       ) {
-        if (!mappedWorkLocations.userServciceRoleDeleted) {
+        if (
+          (serviceID === 2 || serviceID === 4) &&
+          parseInt(mappedWorkLocations.stateID) === this.State.stateID &&
+          parseInt(mappedWorkLocations.workingDistrictID) ===
+            this.District.districtID &&
+          !mappedWorkLocations.userServciceRoleDeleted
+        ) {
+          this.existingRoles.push(mappedWorkLocations.roleID);
+        } else if (
+          serviceID !== 2 &&
+          serviceID !== 4 &&
+          !mappedWorkLocations.userServciceRoleDeleted
+        ) {
           this.existingRoles.push(mappedWorkLocations.roleID); // existing roles has roles which are already mapped.
         }
       }
@@ -2052,6 +2066,13 @@ export class WorkLocationMappingComponent implements OnInit {
     ) {
       this.blockFlag = true;
       this.villageFlag = true;
+      if (serviceline === 'TM' || serviceline === 'MMU') {
+        this.isBlockRequired = false;
+        this.isVillageRequired = false;
+      } else {
+        this.isBlockRequired = true;
+        this.isVillageRequired = true;
+      }
     } else {
       this.blockFlag = false;
       this.villageFlag = false;


### PR DESCRIPTION
## 📋 Description

JIRA ID: AMM-1342

Allowed worklocation mapping till district level... Now if same user can be mapped with roles of same state but different different for MMU and TM servicelines

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [X] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Block and village fields in the work location mapping form are now conditionally required based on the selected service line, providing a more tailored user experience.

- **Chores**
  - Updated the Common-UI library to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->