### PR TITLE
"fix:  sms template list is not loading due to smstype object missing"

### DIFF
--- a/src/app/app-provider-admin/provider-admin/configurations/sms-template/sms-template.component.html
+++ b/src/app/app-provider-admin/provider-admin/configurations/sms-template/sms-template.component.html
@@ -56,7 +56,7 @@
         <ng-container matColumnDef="smsType">
           <th mat-header-cell *matHeaderCellDef>Template Type</th>
           <td mat-cell *matCellDef="let element">
-            {{ element.smsType.smsType }}
+            {{ element.smsType?.smsType || ''}}
           </td>
         </ng-container>
 

--- a/src/app/app-provider-admin/provider-admin/configurations/sms-template/sms-template.component.ts
+++ b/src/app/app-provider-admin/provider-admin/configurations/sms-template/sms-template.component.ts
@@ -200,8 +200,8 @@ export class SmsTemplateComponent implements OnInit, AfterViewInit {
           this.showTableFlag = true;
           this.createForm = false;
           for (let i = 0; i < this.dataSource.data.length; i++) {
-            if (this.dataSource.data[i].deleted === false) {
-              if (this.dataSource.data[i].smsType && this.dataSource.data[i].smsType.smsTypeID !== undefined) {
+            if (this.dataSource.data[i]?.deleted === false) {
+              if (this.dataSource.data[i]?.smsType && this.dataSource.data[i]?.smsType?.smsTypeID !== undefined) {
                 this.smsType_ID_array.push(this.dataSource.data[i].smsType.smsTypeID);
               } else {
                 this.smsType_ID_array.push(null);

--- a/src/app/app-provider-admin/provider-admin/configurations/sms-template/sms-template.component.ts
+++ b/src/app/app-provider-admin/provider-admin/configurations/sms-template/sms-template.component.ts
@@ -201,9 +201,11 @@ export class SmsTemplateComponent implements OnInit, AfterViewInit {
           this.createForm = false;
           for (let i = 0; i < this.dataSource.data.length; i++) {
             if (this.dataSource.data[i].deleted === false) {
-              this.smsType_ID_array.push(
-                this.dataSource.data[i].smsType.smsTypeID,
-              );
+              if (this.dataSource.data[i].smsType && this.dataSource.data[i].smsType.smsTypeID !== undefined) {
+                this.smsType_ID_array.push(this.dataSource.data[i].smsType.smsTypeID);
+              } else {
+                this.smsType_ID_array.push(null);
+              }
             }
           }
         }


### PR DESCRIPTION
## 📋 Description

JIRA ID: 
 sms template list is not loading due to smstype object missing.
 it keep on loading.
 
fix:
checked the smstype object is present or not
if present, push it into the array else, push null.


---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)

---

## ℹ️ Additional Information

![Screenshot from 2025-06-24 18-21-00](https://github.com/user-attachments/assets/3c1d58da-5649-4b6d-bbf3-1d954e342a2d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when processing SMS template data by preventing errors caused by missing or undefined values.
  - Enhanced display of SMS template types to handle missing data gracefully without UI errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->