### PR TITLE
AMM-118: Add employee lock controls in admin UI

### DIFF
--- a/src/app/app-provider-admin/provider-admin/activities/employee-master-new/employee-master-new.component.html
+++ b/src/app/app-provider-admin/provider-admin/activities/employee-master-new/employee-master-new.component.html
@@ -67,6 +67,59 @@
               {{ element.designationName }}
             </td>
           </ng-container>
+          <ng-container matColumnDef="LockStatus">
+            <th mat-header-cell *matHeaderCellDef>Lock Status</th>
+            <td mat-cell *matCellDef="let element">
+              <span *ngIf="element.lockedDueToFailedAttempts">
+                Locked due to failed login attempts
+              </span>
+              <span *ngIf="!element.lockedDueToFailedAttempts && element.deleted === true">
+                Deactivated by administrator
+              </span>
+              <span *ngIf="!element.lockedDueToFailedAttempts && element.deleted !== true">
+                Unlocked
+              </span>
+              <div *ngIf="element.lockedDueToFailedAttempts && element.lockTimestamp">
+                Locked on:
+                {{ element.lockTimestamp | date: 'dd/MM/yyyy, hh:mm a' }}
+              </div>
+            </td>
+          </ng-container>
+          <ng-container matColumnDef="LockAction">
+            <th mat-header-cell *matHeaderCellDef>Lock/Unlock</th>
+            <td mat-cell *matCellDef="let element">
+              <button
+                *ngIf="element.lockedDueToFailedAttempts && element.deleted !== true"
+                mat-raised-button
+                color="accent"
+                class="mat_green"
+                matTooltip="Unlock account locked due to failed login attempts"
+                (click)="unlockUserAccount(element.userID, element.userName)"
+              >
+                Unlock
+              </button>
+              <button
+                *ngIf="!element.lockedDueToFailedAttempts && element.deleted !== true"
+                mat-raised-button
+                class="mat_blue"
+                color="primary"
+                matTooltip="Lock account"
+                (click)="lockUserAccount(element.userID, element.userName)"
+              >
+                Lock
+              </button>
+              <button
+                *ngIf="element.deleted === true"
+                mat-raised-button
+                class="mat_blue"
+                color="primary"
+                disabled
+                matTooltip="Activate the account before changing lock status"
+              >
+                {{ element.lockedDueToFailedAttempts ? 'Unlock' : 'Lock' }}
+              </button>
+            </td>
+          </ng-container>
           <ng-container matColumnDef="edit">
             <th mat-header-cell *matHeaderCellDef>Edit</th>
             <td mat-cell *matCellDef="let element">
@@ -86,10 +139,10 @@
           <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
           <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
           <ng-container matColumnDef="action">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header>Action</th>
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Activate/Deactivate</th>
             <td mat-cell *matCellDef="let element">
               <button
-                *ngIf="element.deleted === true"
+                *ngIf="!element.lockedDueToFailedAttempts && element.deleted === true"
                 mat-raised-button
                 color="accent"
                 class="mat_green"
@@ -98,7 +151,7 @@
                 Activate
               </button>
               <button
-                *ngIf="element.deleted === false"
+                *ngIf="!element.lockedDueToFailedAttempts && element.deleted === false"
                 mat-raised-button
                 class="mat_blue"
                 color="primary"

--- a/src/app/app-provider-admin/provider-admin/activities/employee-master-new/employee-master-new.component.ts
+++ b/src/app/app-provider-admin/provider-admin/activities/employee-master-new/employee-master-new.component.ts
@@ -59,6 +59,8 @@ export class EmployeeMasterNewComponent implements OnInit {
     'EmailID',
     'DOJ',
     'Designation',
+    'LockStatus',
+    'LockAction',
     'edit',
     'action',
   ];
@@ -1629,6 +1631,89 @@ export class EmployeeMasterNewComponent implements OnInit {
         },
       );
   }
+
+  unlockUserAccount(userID: number, userName: string) {
+    this.dialogService
+      .confirm(
+        'Confirm Unlock',
+        `Are you sure you want to unlock the account for user "${userName}"? This will reset their failed login attempts and allow them to log in again.`,
+      )
+      .subscribe(
+        (res) => {
+          if (res) {
+            this.employeeMasterNewService.unlockUserAccount(userID).subscribe(
+              (response: any) => {
+                if (response && response.statusCode === 200) {
+                  this.dialogService.alert(
+                    'User account unlocked successfully. The user can now log in.',
+                    'success',
+                  );
+                  this.getAllUserDetails();
+                  this.searchTerm = null;
+                } else {
+                  this.dialogService.alert(
+                    response?.errorMessage || 'Failed to unlock user account',
+                    'error',
+                  );
+                }
+              },
+              (err) => {
+                console.log('error', err);
+                this.dialogService.alert(
+                  'Error unlocking user account. Please try again.',
+                  'error',
+                );
+              },
+            );
+          }
+        },
+        (err) => {
+          console.log(err);
+        },
+      );
+  }
+
+  lockUserAccount(userID: number, userName: string) {
+    this.dialogService
+      .confirm(
+        'Confirm Lock',
+        `Are you sure you want to lock the account for user "${userName}"? The user will not be able to log in until the account is unlocked or the lock period expires.`,
+      )
+      .subscribe(
+        (res) => {
+          if (res) {
+            this.employeeMasterNewService.lockUserAccount(userID).subscribe(
+              (response: any) => {
+                if (response && response.statusCode === 200) {
+                  this.dialogService.alert(
+                    'User account locked successfully.',
+                    'success',
+                  );
+                  this.getAllUserDetails();
+                  this.searchTerm = null;
+                } else {
+                  this.dialogService.alert(
+                    response?.errorMessage || 'Failed to lock user account',
+                    'error',
+                  );
+                }
+              },
+              (err) => {
+                console.log('error', err);
+                this.dialogService.alert(
+                  'Error locking user account. Please try again.',
+                  'error',
+                );
+              },
+            );
+          }
+        },
+        (err) => {
+          console.log(err);
+        },
+      );
+  }
+
   filterComponentList(searchTerm?: string) {
     if (!searchTerm) {
       this.refreshFilteredData(this.searchResult);

--- a/src/app/app-provider-admin/provider-admin/activities/services/employee-master-new-services.service.ts
+++ b/src/app/app-provider-admin/provider-admin/activities/services/employee-master-new-services.service.ts
@@ -188,4 +188,16 @@ export class EmployeeMasterNewServices {
     // .map(this.extractData)
     // .catch(this.handleError)
   }
+
+  unlockUserAccount(userId: number): Observable<any> {
+    return this.http.post(environment.unlockUserAccountUrl, {
+      userId: userId,
+    });
+  }
+
+  lockUserAccount(userId: number): Observable<any> {
+    return this.http.post(environment.lockUserAccountUrl, {
+      userId: userId,
+    });
+  }
 }

--- a/src/app/user-login/login/login.component.ts
+++ b/src/app/user-login/login/login.component.ts
@@ -212,6 +212,8 @@ export class loginContentClassComponent implements OnInit, OnDestroy {
                       this.loginservice.dologoutUsrFromPreSession(true);
                     }
                   });
+              } else {
+                this.alertMessage.alert(response.errorMessage, 'error');
               }
             }
           },
@@ -282,6 +284,8 @@ export class loginContentClassComponent implements OnInit, OnDestroy {
                       this.loginservice.dologoutUsrFromPreSession(true);
                     }
                   });
+              } else {
+                this.alertMessage.alert(response.errorMessage, 'error');
               }
             }
           },

--- a/src/environments/environment.ci.ts.template
+++ b/src/environments/environment.ci.ts.template
@@ -228,6 +228,8 @@ export const environment = {
   editUserDetailsUrl: `${adminBaseUrl}editUserDetails`,
   userActivationDeactivationUrl: `${adminBaseUrl}deletedUserDetails`,
   checkEmpIdAvailabilityUrl: `${adminBaseUrl}m/FindEmployeeDetails`,
+  lockUserAccountUrl: `${commonBaseURL}user/lockUserAccount`,
+  unlockUserAccountUrl: `${commonBaseURL}user/unlockUserAccount`,
   getStates_url: `${adminBaseUrl}m/role/state`,
   getDistricts_url: `${adminBaseUrl}m/location/findDistrict`,
   getServiceLines_url: `${adminBaseUrl}m/role/service`,

--- a/src/environments/environment.local.ts
+++ b/src/environments/environment.local.ts
@@ -228,6 +228,11 @@ export const environment = {
   editUserDetailsUrl: `${adminBaseUrl}editUserDetails`,
   userActivationDeactivationUrl: `${adminBaseUrl}deletedUserDetails`,
   checkEmpIdAvailabilityUrl: `${adminBaseUrl}m/FindEmployeeDetails`,
+
+  // User Account Lock Management APIs (Common-API)
+  lockUserAccountUrl: `${commonBaseURL}user/lockUserAccount`,
+  unlockUserAccountUrl: `${commonBaseURL}user/unlockUserAccount`,
+
   getStates_url: `${adminBaseUrl}m/role/state`,
   getDistricts_url: `${adminBaseUrl}m/location/findDistrict`,
   getServiceLines_url: `${adminBaseUrl}m/role/service`,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -226,6 +226,11 @@ export const environment = {
   editUserDetailsUrl: `${adminBaseUrl}editUserDetails`,
   userActivationDeactivationUrl: `${adminBaseUrl}deletedUserDetails`,
   checkEmpIdAvailabilityUrl: `${adminBaseUrl}m/FindEmployeeDetails`,
+
+  // User Account Lock Management APIs (Common-API)
+  lockUserAccountUrl: `${commonBaseURL}user/lockUserAccount`,
+  unlockUserAccountUrl: `${commonBaseURL}user/unlockUserAccount`,
+
   getStates_url: `${adminBaseUrl}m/role/state`,
   getDistricts_url: `${adminBaseUrl}m/location/findDistrict`,
   getServiceLines_url: `${adminBaseUrl}m/role/service`,

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -222,6 +222,11 @@ export const environment = {
   editUserDetailsUrl: `${adminBaseUrl}editUserDetails`,
   userActivationDeactivationUrl: `${adminBaseUrl}deletedUserDetails`,
   checkEmpIdAvailabilityUrl: `${adminBaseUrl}m/FindEmployeeDetails`,
+
+  // User Account Lock Management APIs (Common-API)
+  lockUserAccountUrl: `${commonBaseURL}user/lockUserAccount`,
+  unlockUserAccountUrl: `${commonBaseURL}user/unlockUserAccount`,
+
   getStates_url: `${adminBaseUrl}m/role/state`,
   getDistricts_url: `${adminBaseUrl}m/location/findDistrict`,
   getServiceLines_url: `${adminBaseUrl}m/role/service`,


### PR DESCRIPTION
Part of https://github.com/PSMRI/AMRIT/issues/118
## Description

Updates Employee Master so admins can see lock state on load and act on it using explicit Lock/Unlock controls.

## Changes
- show lock state inline in the employee list
- add a dedicated Lock/Unlock column driven by account state
- show `Lock` for activated and unlocked users
- show `Unlock` for activated and locked users
- disable lock control for deactivated users
- keep activate/deactivate controls separate from lock controls
- wire the UI to the Common-API lock/unlock endpoints

## Why this shape was required
- review comments asked to avoid a per-user lock-status fetch
- review comments explicitly asked for Lock/Unlock behavior based on the account state matrix
- lock state is expected to render directly from the SearchEmployee4 response

## Testing
- validated lock/unlock rendering and action flow against the local docker stack