### PR TITLE
fix: unlock button disabled after locking a user account (AMM-2343)

### DIFF
--- a/src/app/app-provider-admin/provider-admin/activities/employee-master-new/employee-master-new.component.html
+++ b/src/app/app-provider-admin/provider-admin/activities/employee-master-new/employee-master-new.component.html
@@ -89,7 +89,7 @@
             <th mat-header-cell *matHeaderCellDef>Lock/Unlock</th>
             <td mat-cell *matCellDef="let element">
               <button
-                *ngIf="element.lockedDueToFailedAttempts && element.deleted !== true"
+                *ngIf="element.lockedDueToFailedAttempts"
                 mat-raised-button
                 color="accent"
                 class="mat_green"
@@ -109,14 +109,14 @@
                 Lock
               </button>
               <button
-                *ngIf="element.deleted === true"
+                *ngIf="element.deleted === true && !element.lockedDueToFailedAttempts"
                 mat-raised-button
                 class="mat_blue"
                 color="primary"
                 disabled
                 matTooltip="Activate the account before changing lock status"
               >
-                {{ element.lockedDueToFailedAttempts ? 'Unlock' : 'Lock' }}
+                Lock
               </button>
             </td>
           </ng-container>


### PR DESCRIPTION
## Summary
- Locking a user account sets `deleted=true` and `lockedDueToFailedAttempts=true`. The Unlock button required `deleted !== true` to render, so a locked account had no enabled control left to unlock it (reported on Assam UAT: lock works, but Unlock button is disabled afterward).
- Unlock now shows whenever `lockedDueToFailedAttempts` is true, regardless of `deleted`, matching the logic already present on `main`/`release-3.6.2`.
- The disabled "Activate the account before changing lock status" button now only shows when the account is deactivated but not lock-flagged, and its label is fixed to "Lock" (it can never represent an unlock action while disabled).

## Test plan
- [ ] Lock a user account in Admin-UI
- [ ] Confirm the Unlock button is now enabled and visible
- [ ] Click Unlock and confirm the account unlocks successfully
- [ ] Confirm a separately deactivated (non-locked) account still shows the disabled "Activate the account before changing lock status" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)